### PR TITLE
feat(phase-5): polish and error hardening

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -11,6 +11,10 @@ import (
 )
 
 type dirChangedMsg struct{ path string }
+type dirReadErrMsg struct {
+	path string
+	err  error
+}
 
 var audioExts = map[string]bool{
 	".mp3": true, ".opus": true, ".m4a": true,
@@ -52,7 +56,12 @@ func sortEntries(entries []os.DirEntry) {
 func (m browserModel) changeDir(dir string) (browserModel, tea.Cmd) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return m, nil
+		m.dir = dir
+		m.entries = nil
+		m.cursor = 0
+		m.offset = 0
+		m.selected = make(map[int]bool)
+		return m, func() tea.Msg { return dirReadErrMsg{dir, err} }
 	}
 	sortEntries(entries)
 	m.dir = dir

--- a/main.go
+++ b/main.go
@@ -24,6 +24,12 @@ func main() {
 		}
 	}
 
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		fmt.Fprintf(os.Stderr, "not a directory: %s\n", dir)
+		os.Exit(1)
+	}
+
 	_, ffmpegErr := exec.LookPath("ffmpeg")
 	ffmpegAvailable := ffmpegErr == nil
 

--- a/model.go
+++ b/model.go
@@ -39,11 +39,15 @@ type model struct {
 }
 
 func newModel(dir string, ffmpegAvailable bool) model {
-	return model{
+	m := model{
 		mode:            modeBrowse,
 		browser:         newBrowserModel(dir),
 		ffmpegAvailable: ffmpegAvailable,
 	}
+	if !ffmpegAvailable {
+		m.statusMsg = "ffmpeg not found — conversion disabled"
+	}
+	return m
 }
 
 func (m model) Init() tea.Cmd {
@@ -132,6 +136,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tagErrMsg:
 		m.mode = modeBrowse
 		m.statusMsg = "Tag error: " + msg.err.Error()
+		m.statusIsError = true
+		return m, nil
+
+	case dirReadErrMsg:
+		m.statusMsg = "Cannot read directory: " + msg.err.Error()
 		m.statusIsError = true
 		return m, nil
 


### PR DESCRIPTION
## Summary

- **`main.go`**: Validates start directory exists before launching TUI; exits with error to stderr if invalid. Sets informational `"ffmpeg not found — conversion disabled"` status when ffmpeg is absent.
- **`browser.go`**: Adds `dirReadErrMsg` type; `changeDir` now emits it (with empty listing) on `os.ReadDir` failure instead of silently no-oping.
- **`model.go`**: Handles `dirReadErrMsg` → sets error status. `newModel` sets ffmpeg-missing status at startup (non-error color).

## Test plan

- [ ] Pass a non-existent directory as arg → clean error printed to stderr, exits before TUI
- [ ] Run without ffmpeg in PATH → TUI opens with info status, `:convert` shows error
- [ ] Navigate to a permission-denied directory → error in status bar, browser shows empty listing, navigation still works
- [ ] Resize terminal in tag mode → no visual corruption

🤖 Generated with [Claude Code](https://claude.com/claude-code)