### PR TITLE
feat(browser): add hidden file filtering and symlink styling

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -26,12 +26,31 @@ func isAudio(name string) bool {
 }
 
 type browserModel struct {
-	dir      string
-	entries  []os.DirEntry
-	cursor   int
-	offset   int
-	selected map[int]bool
-	height   int
+	dir        string
+	entries    []os.DirEntry
+	cursor     int
+	offset     int
+	selected   map[int]bool
+	height     int
+	showHidden bool
+}
+
+func isSymlinkToDir(entry os.DirEntry, dir string) bool {
+	if entry.Type()&os.ModeSymlink == 0 {
+		return false
+	}
+	info, err := os.Stat(filepath.Join(dir, entry.Name()))
+	return err == nil && info.IsDir()
+}
+
+func filterEntries(entries []os.DirEntry, showHidden bool) []os.DirEntry {
+	var result []os.DirEntry
+	for _, e := range entries {
+		if showHidden || !strings.HasPrefix(e.Name(), ".") {
+			result = append(result, e)
+		}
+	}
+	return result
 }
 
 func newBrowserModel(dir string) browserModel {
@@ -41,6 +60,7 @@ func newBrowserModel(dir string) browserModel {
 	}
 	entries, err := os.ReadDir(dir)
 	if err == nil {
+		entries = filterEntries(entries, false)
 		sortEntries(entries)
 		m.entries = entries
 	}
@@ -63,6 +83,7 @@ func (m browserModel) changeDir(dir string) (browserModel, tea.Cmd) {
 		m.selected = make(map[int]bool)
 		return m, func() tea.Msg { return dirReadErrMsg{dir, err} }
 	}
+	entries = filterEntries(entries, m.showHidden)
 	sortEntries(entries)
 	m.dir = dir
 	m.entries = entries
@@ -101,9 +122,11 @@ func (m browserModel) Update(msg tea.Msg) (browserModel, tea.Cmd) {
 		case "k", "up":
 			m = m.scrollUp()
 		case "enter":
-			if len(m.entries) > 0 && m.entries[m.cursor].IsDir() {
-				newDir := filepath.Join(m.dir, m.entries[m.cursor].Name())
-				return m.changeDir(newDir)
+			if len(m.entries) > 0 {
+				entry := m.entries[m.cursor]
+				if entry.IsDir() || isSymlinkToDir(entry, m.dir) {
+					return m.changeDir(filepath.Join(m.dir, entry.Name()))
+				}
 			}
 		case "h":
 			parent := filepath.Dir(m.dir)
@@ -111,10 +134,15 @@ func (m browserModel) Update(msg tea.Msg) (browserModel, tea.Cmd) {
 				return m.changeDir(parent)
 			}
 		case "l":
-			if len(m.entries) > 0 && m.entries[m.cursor].IsDir() {
-				newDir := filepath.Join(m.dir, m.entries[m.cursor].Name())
-				return m.changeDir(newDir)
+			if len(m.entries) > 0 {
+				entry := m.entries[m.cursor]
+				if entry.IsDir() || isSymlinkToDir(entry, m.dir) {
+					return m.changeDir(filepath.Join(m.dir, entry.Name()))
+				}
 			}
+		case "i":
+			m.showHidden = !m.showHidden
+			return m.changeDir(m.dir)
 		case " ":
 			if len(m.entries) > 0 {
 				m.selected[m.cursor] = !m.selected[m.cursor]
@@ -175,6 +203,12 @@ func (m browserModel) View(width, height int) string {
 			styledName = styleSelected.Render(displayName)
 		case entry.IsDir():
 			styledName = styleDir.Render(name + "/")
+		case entry.Type()&os.ModeSymlink != 0:
+			if isSymlinkToDir(entry, m.dir) {
+				styledName = styleSymlink.Render(name + "@/")
+			} else {
+				styledName = styleSymlink.Render(name + "@")
+			}
 		case isAudio(name):
 			styledName = styleAudio.Render(name)
 		case strings.HasPrefix(name, "."):

--- a/browser_test.go
+++ b/browser_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestReadDirSortOrder(t *testing.T) {
@@ -81,6 +83,136 @@ func TestSelectedEntries_MultiSelected(t *testing.T) {
 	}
 	if result[1].Name() != "c.mp3" {
 		t.Errorf("expected c.mp3, got %s", result[1].Name())
+	}
+}
+
+func TestFilterEntries_HidesHidden(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "visible.mp3"), nil, 0644)
+	os.WriteFile(filepath.Join(dir, ".hidden"), nil, 0644)
+	os.MkdirAll(filepath.Join(dir, "subdir"), 0755)
+
+	entries, _ := os.ReadDir(dir)
+	filtered := filterEntries(entries, false)
+
+	for _, e := range filtered {
+		if e.Name() == ".hidden" {
+			t.Error(".hidden should not appear when showHidden=false")
+		}
+	}
+	names := make(map[string]bool)
+	for _, e := range filtered {
+		names[e.Name()] = true
+	}
+	if !names["visible.mp3"] {
+		t.Error("visible.mp3 should be present")
+	}
+	if !names["subdir"] {
+		t.Error("subdir should be present")
+	}
+}
+
+func TestFilterEntries_ShowsHidden(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "visible.mp3"), nil, 0644)
+	os.WriteFile(filepath.Join(dir, ".hidden"), nil, 0644)
+	os.MkdirAll(filepath.Join(dir, "subdir"), 0755)
+
+	entries, _ := os.ReadDir(dir)
+	filtered := filterEntries(entries, true)
+
+	if len(filtered) != 3 {
+		t.Errorf("expected 3 entries, got %d", len(filtered))
+	}
+}
+
+func TestFilterEntries_AlwaysShowsSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.mp3")
+	os.WriteFile(target, nil, 0644)
+	link := filepath.Join(dir, "link.mp3")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skip("symlinks not supported:", err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	filtered := filterEntries(entries, false)
+
+	names := make(map[string]bool)
+	for _, e := range filtered {
+		names[e.Name()] = true
+	}
+	if !names["link.mp3"] {
+		t.Error("symlink should be visible when showHidden=false")
+	}
+}
+
+func TestToggleHidden_ReloadsDir(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "song.mp3"), nil, 0644)
+	os.WriteFile(filepath.Join(dir, ".dotfile"), nil, 0644)
+
+	m := newBrowserModel(dir)
+	for _, e := range m.entries {
+		if e.Name() == ".dotfile" {
+			t.Error(".dotfile should be hidden initially")
+		}
+	}
+
+	keyI := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("i")}
+	m2, _ := m.Update(keyI)
+	found := false
+	for _, e := range m2.entries {
+		if e.Name() == ".dotfile" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error(".dotfile should be visible after toggling i")
+	}
+
+	m3, _ := m2.Update(keyI)
+	for _, e := range m3.entries {
+		if e.Name() == ".dotfile" {
+			t.Error(".dotfile should be hidden again after second toggle")
+		}
+	}
+}
+
+func TestFollowSymlinkToDir(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "realdir")
+	if err := os.MkdirAll(target, 0755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(target, "song.mp3"), nil, 0644)
+
+	link := filepath.Join(root, "linkdir")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skip("symlinks not supported:", err)
+	}
+
+	m := newBrowserModel(root)
+
+	// find the symlink entry index
+	idx := -1
+	for i, e := range m.entries {
+		if e.Name() == "linkdir" {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		t.Fatal("linkdir not found in entries")
+	}
+	m.cursor = idx
+
+	m2, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("l")})
+	if m2.dir != link {
+		t.Errorf("expected dir %s, got %s", link, m2.dir)
+	}
+	if len(m2.entries) == 0 || m2.entries[0].Name() != "song.mp3" {
+		t.Error("expected song.mp3 inside followed symlink dir")
 	}
 }
 

--- a/styles.go
+++ b/styles.go
@@ -13,4 +13,5 @@ var (
 	styleTagLabel   = lipgloss.NewStyle().Width(10).Align(lipgloss.Right)
 	styleTagFocused = lipgloss.NewStyle().Underline(true)
 	styleCmdPrefix  = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	styleSymlink    = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
 )


### PR DESCRIPTION
The file browser now supports toggling the visibility of hidden files
(those prefixed with a dot) using the 'i' key. This improves the user
experience by reducing clutter in directories with many configuration
files while allowing access when necessary.

Additionally, symlinks are now visually distinguished with a specific
color and an '@' suffix in the view. Comprehensive tests were added to
ensure filtering logic correctly handles various file types and state
transitions.

Update the file browser to support traversing symbolic links that point
to directories. Previously, the browser only allowed navigation into
standard directory entries.

The implementation adds an `isSymlinkToDir` helper that resolves link
targets using `os.Stat`. Navigation logic for "enter" and "l" keys now
includes this check. The UI is updated to append a trailing slash to
directory symlinks (e.g., `name@/`) for better visual clarity.
