### PR TITLE
fix(converter): preserve metadata when converting ogg and opus files

### DIFF
--- a/converter.go
+++ b/converter.go
@@ -31,8 +31,18 @@ func convertFile(ctx context.Context, src, destDir string) tea.Cmd {
 			return convertSkippedMsg{src}
 		}
 
-		cmd := exec.CommandContext(ctx, "ffmpeg", "-y", "-i", src,
-			"-codec:a", "libmp3lame", "-qscale:a", "2", dest)
+		// ogg/opus store user tags in stream-level metadata (Vorbis Comments),
+		// so they must be mapped to global output metadata explicitly.
+		// m4a stores tags at the container level, so -map_metadata 0 suffices.
+		metaArgs := []string{"-map_metadata", "0"}
+		ext := strings.ToLower(filepath.Ext(src))
+		if ext == ".opus" || ext == ".ogg" {
+			metaArgs = []string{"-map_metadata:g", "0:s:0"}
+		}
+
+		args := append([]string{"-y", "-i", src}, metaArgs...)
+		args = append(args, "-codec:a", "libmp3lame", "-qscale:a", "2", dest)
+		cmd := exec.CommandContext(ctx, "ffmpeg", args...)
 		cmd.Stdout = nil
 		cmd.Stderr = nil
 

--- a/converter_test.go
+++ b/converter_test.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
+
+	id3 "github.com/bogem/id3v2/v2"
 )
 
 func TestMain(m *testing.M) {
@@ -153,6 +155,49 @@ func TestConvertSkipsExisting(t *testing.T) {
 	msg := convertFile(context.Background(), src, dir)()
 	if _, ok := msg.(convertSkippedMsg); !ok {
 		t.Fatalf("second convert: expected convertSkippedMsg, got %T", msg)
+	}
+}
+
+func TestConvertCopiesMetadata(t *testing.T) {
+	skipIfNoFFmpeg(t)
+
+	dir := t.TempDir()
+	src := filepath.Join(dir, "tagged.opus")
+
+	// Create an opus file with embedded metadata.
+	cmd := exec.Command("ffmpeg",
+		"-f", "lavfi", "-i", "anullsrc=r=48000:cl=mono",
+		"-t", "0.5", "-c:a", "libopus",
+		"-metadata", "title=TestTitle",
+		"-metadata", "artist=TestArtist",
+		"-metadata", "album=TestAlbum",
+		src)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to create tagged opus: %v", err)
+	}
+
+	msg := convertFile(context.Background(), src, dir)()
+	done, ok := msg.(convertDoneMsg)
+	if !ok {
+		t.Fatalf("expected convertDoneMsg, got %T: %v", msg, msg)
+	}
+
+	tag, err := id3.Open(done.dest, id3.Options{Parse: true})
+	if err != nil {
+		t.Fatalf("failed to open output mp3: %v", err)
+	}
+	defer tag.Close()
+
+	if tag.Title() != "TestTitle" {
+		t.Errorf("title: got %q, want %q", tag.Title(), "TestTitle")
+	}
+	if tag.Artist() != "TestArtist" {
+		t.Errorf("artist: got %q, want %q", tag.Artist(), "TestArtist")
+	}
+	if tag.Album() != "TestAlbum" {
+		t.Errorf("album: got %q, want %q", tag.Album(), "TestAlbum")
 	}
 }
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -90,8 +90,7 @@ commands.go          — command-bar parsing & dispatch
 
 ### 2. Audio Conversion
 
-Converts audio files to `.mp3` by shelling out 
-to `ffmpeg`. 
+Converts audio files to `.mp3` by shelling out to `ffmpeg`.
 
 Supported formats: `.opus`, `.ogg`, `.m4a`
 
@@ -101,13 +100,15 @@ Place the cursor on a file (or `Space`-select it) and run `:convert`.
 The tool executes:
 
 ```text
-ffmpeg -y -i input.opus -codec:a libmp3lame -qscale:a 2 output.mp3
+ffmpeg -y -i input.opus -map_metadata:g 0:s:0 \
+    -codec:a libmp3lame -qscale:a 2 output.mp3
 ```
 
 - Output file is placed in the same directory with the `.mp3`
   extension.
 - Source file is kept (not deleted).
-- ID3 tags are carried over automatically by ffmpeg where supported.
+- Metadata from the source file is copied into the output ID3 tag
+  (see [Metadata copying](#metadata-copying) below).
 
 #### Bulk convert
 
@@ -124,6 +125,25 @@ Select a directory (or multi-select files) and run `:convert`.
   `Conversion complete (N converted, M skipped, E errors)`.
 - The browser directory is refreshed automatically when conversion
   finishes so new `.mp3` files appear immediately.
+
+#### Metadata copying
+
+When converting, the tool copies metadata from the source file into
+the ID3 tag of the output `.mp3`. The six standard fields — Title,
+Artist, Album, Year, Track, and Genre — are preserved where present.
+
+Different container formats store tags at different levels, so the
+`-map_metadata` flag passed to `ffmpeg` varies by extension:
+
+| Format  | Tag storage                | ffmpeg flag                  |
+|---------|----------------------------|------------------------------|
+| `.m4a`  | Container atoms (global)   | `-map_metadata 0`            |
+| `.opus` | Vorbis Comments (stream)   | `-map_metadata:g 0:s:0`      |
+| `.ogg`  | Vorbis Comments (stream)   | `-map_metadata:g 0:s:0`      |
+
+The `:g` specifier on the output side ensures all tags land in the
+global (file-level) ID3 header rather than being attached to the
+audio stream.
 
 #### Cancellation
 


### PR DESCRIPTION
FFmpeg requires explicit stream-to-global mapping to correctly extract
Vorbis Comments from Ogg and Opus containers into MP3 ID3 tags. Without
this, metadata like artist and title are lost during conversion.

This update applies `-map_metadata:g 0:s:0` for Ogg/Opus sources and
defaults to `-map_metadata 0` for other formats. A new regression test
verifies tag preservation using a temporary tagged Opus file.
