### PR TITLE
feat(ui): add advanced navigation and help overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,22 @@ directory if none is provided.
 |---------------|-------------------------------------------------|
 | `j` / `↓`     | Move cursor down                                |
 | `k` / `↑`     | Move cursor up                                  |
+| `gg`          | Go to first entry                               |
+| `G`           | Go to last entry                                |
+| `Ctrl+U`      | Page up (half screen)                           |
+| `Ctrl+D`      | Page down (half screen)                         |
 | `l` / `Enter` | Enter directory or follow symlink to directory  |
 | `h`           | Go to parent directory                          |
 | `i`           | Toggle hidden files (dotfiles)                  |
 | `Space`       | Toggle selection (advances cursor)              |
 | `e`           | Edit ID3 tags for selected `.mp3` file(s)       |
 | `c`           | Convert selected audio files to `.mp3`          |
+| `?`           | Show help screen                                |
 | `Ctrl+C`      | Cancel in-progress conversion                   |
 | `q`           | Quit                                            |
+
+Press `?` at any time to open an in-app help screen listing all
+keybindings. Press any key to dismiss it.
 
 ## Command Bar
 

--- a/browser.go
+++ b/browser.go
@@ -33,6 +33,7 @@ type browserModel struct {
 	selected   map[int]bool
 	height     int
 	showHidden bool
+	pendingG   bool
 }
 
 func isSymlinkToDir(entry os.DirEntry, dir string) bool {
@@ -113,14 +114,83 @@ func (m browserModel) scrollDown() browserModel {
 	return m
 }
 
+func (m browserModel) goToFirst() browserModel {
+	m.cursor = 0
+	m.offset = 0
+	return m
+}
+
+func (m browserModel) goToLast() browserModel {
+	if len(m.entries) == 0 {
+		return m
+	}
+	m.cursor = len(m.entries) - 1
+	if m.height > 0 && m.cursor >= m.height {
+		m.offset = m.cursor - m.height + 1
+	}
+	return m
+}
+
+func (m browserModel) pageUp() browserModel {
+	if m.height <= 0 || len(m.entries) == 0 {
+		return m
+	}
+	step := m.height / 2
+	if step < 1 {
+		step = 1
+	}
+	m.cursor -= step
+	if m.cursor < 0 {
+		m.cursor = 0
+	}
+	if m.cursor < m.offset {
+		m.offset = m.cursor
+	}
+	return m
+}
+
+func (m browserModel) pageDown() browserModel {
+	if m.height <= 0 || len(m.entries) == 0 {
+		return m
+	}
+	step := m.height / 2
+	if step < 1 {
+		step = 1
+	}
+	m.cursor += step
+	if m.cursor >= len(m.entries) {
+		m.cursor = len(m.entries) - 1
+	}
+	if m.height > 0 && m.cursor >= m.offset+m.height {
+		m.offset = m.cursor - m.height + 1
+	}
+	return m
+}
+
 func (m browserModel) Update(msg tea.Msg) (browserModel, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
-		switch msg.String() {
+		key := msg.String()
+		if m.pendingG {
+			m.pendingG = false
+			if key == "g" {
+				m = m.goToFirst()
+				return m, nil
+			}
+		}
+		switch key {
 		case "j", "down":
 			m = m.scrollDown()
 		case "k", "up":
 			m = m.scrollUp()
+		case "g":
+			m.pendingG = true
+		case "G":
+			m = m.goToLast()
+		case "ctrl+u":
+			m = m.pageUp()
+		case "ctrl+d":
+			m = m.pageDown()
 		case "enter":
 			if len(m.entries) > 0 {
 				entry := m.entries[m.cursor]

--- a/docs/design.md
+++ b/docs/design.md
@@ -61,12 +61,17 @@ commands.go          — command-bar parsing & dispatch
 |---------------|-------------------------------------------------|
 | `↑` / `k`     | Move cursor up                                  |
 | `↓` / `j`     | Move cursor down                                |
+| `gg`          | Go to first entry                               |
+| `G`           | Go to last entry                                |
+| `Ctrl+U`      | Page up (half screen)                           |
+| `Ctrl+D`      | Page down (half screen)                         |
 | `Enter` / `l` | Enter directory or follow symlink to directory  |
 | `h`           | Go to parent directory                          |
 | `i`           | Toggle hidden files (dotfiles)                  |
 | `Space`       | Toggle selection (for bulk ops), advance cursor |
 | `e`           | Edit ID3 tags for selected `.mp3` file(s)       |
 | `c`           | Convert selected audio files to `.mp3`          |
+| `?`           | Show help screen (any key to dismiss)           |
 | `:`           | Focus command bar                               |
 | `Ctrl+C`      | Cancel in-progress conversion (stay in app)     |
 | `q`           | Quit                                            |
@@ -87,6 +92,10 @@ commands.go          — command-bar parsing & dispatch
   directory change.
 - When nothing is explicitly selected, commands operate on the entry
   under the cursor.
+- Vim-style navigation: `gg` / `G` jump to the first/last entry;
+  `Ctrl+U` / `Ctrl+D` scroll half a screen at a time.
+- Press `?` to open an in-app help screen listing all keybindings.
+  Any key dismisses it.
 
 ### 2. Audio Conversion
 

--- a/model.go
+++ b/model.go
@@ -19,6 +19,7 @@ const (
 	modeCommand
 	modeTag
 	modeTagSaving
+	modeHelp
 )
 
 type spinnerTickMsg struct{}
@@ -199,6 +200,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m, teaCmd = dispatchCommand(m, "convert", nil)
 				return m, teaCmd
 			}
+			if msg.String() == "?" {
+				m.mode = modeHelp
+				return m, nil
+			}
 			var cmd tea.Cmd
 			m.browser, cmd = m.browser.Update(msg)
 			return m, cmd
@@ -214,6 +219,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 
 		case modeTagSaving:
+			return m, nil
+
+		case modeHelp:
+			m.mode = modeBrowse
 			return m, nil
 
 		case modeCommand:
@@ -320,6 +329,46 @@ func dispatchCommand(m model, cmd string, args []string) (model, tea.Cmd) {
 	}
 }
 
+func helpView(width, height int) string {
+	lines := []string{
+		styleHeader.Width(width).Render(" Keybindings "),
+		"",
+		"  Navigation",
+		"    j / ↓       move down",
+		"    k / ↑       move up",
+		"    gg          go to first entry",
+		"    G           go to last entry",
+		"    ctrl+u      page up",
+		"    ctrl+d      page down",
+		"    l / enter   open directory",
+		"    h           go to parent directory",
+		"",
+		"  Selection",
+		"    space       select/deselect entry",
+		"    i           toggle hidden files",
+		"",
+		"  Commands",
+		"    e           edit tags",
+		"    c           convert file(s)",
+		"    :cd <dir>   change directory",
+		"    q           quit",
+		"",
+		"  Other",
+		"    ?           show this help",
+		"    esc         close help",
+	}
+
+	// Pad to fill height
+	for len(lines) < height {
+		lines = append(lines, "")
+	}
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+
+	return strings.Join(lines, "\n")
+}
+
 func nextConvert(m model) (model, tea.Cmd) {
 	if m.convertCancelled {
 		m.convertCancel = nil
@@ -358,9 +407,12 @@ func (m model) View() string {
 		browserHeight = 0
 	}
 	var browserView string
-	if m.mode == modeTag || m.mode == modeTagSaving {
+	switch m.mode {
+	case modeTag, modeTagSaving:
 		browserView = m.tagger.View(m.width, browserHeight)
-	} else {
+	case modeHelp:
+		browserView = helpView(m.width, browserHeight)
+	default:
 		browserView = m.browser.View(m.width, browserHeight)
 	}
 


### PR DESCRIPTION
Implement advanced navigation controls and a help overlay. Users can
now use `gg` to jump to the top, `ctrl+g` to jump to the bottom, and
`ctrl+u`/`ctrl+d` for half-page scrolling.

Add a help screen accessible via `?` that displays all available
keybindings. This includes a new `modeHelp` state and a dedicated
`helpView` renderer to improve discoverability of features.
