### PR TITLE
Displaying Tag information in navigator view

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"strings"
 
+	id3 "github.com/bogem/id3v2/v2"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -25,9 +26,55 @@ func isAudio(name string) bool {
 	return audioExts[strings.ToLower(filepath.Ext(name))]
 }
 
+type tagSummary struct {
+	artist string
+	title  string
+}
+
+func (t tagSummary) display() string {
+	switch {
+	case t.artist != "" && t.title != "":
+		return t.artist + " · " + t.title
+	case t.artist != "":
+		return t.artist
+	case t.title != "":
+		return t.title
+	}
+	return ""
+}
+
+func readTagSummary(path string) tagSummary {
+	tag, err := id3.Open(path, id3.Options{Parse: true})
+	if err != nil {
+		return tagSummary{}
+	}
+	defer tag.Close()
+	return tagSummary{artist: tag.Artist(), title: tag.Title()}
+}
+
+func loadTagCache(entries []os.DirEntry, dir string) map[string]tagSummary {
+	cache := make(map[string]tagSummary)
+	for _, e := range entries {
+		if !e.IsDir() && strings.ToLower(filepath.Ext(e.Name())) == ".mp3" {
+			cache[e.Name()] = readTagSummary(filepath.Join(dir, e.Name()))
+		}
+	}
+	return cache
+}
+
+// truncateRunes shortens s to at most max visible characters, appending "…".
+func truncateRunes(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max-1]) + "…"
+}
+
 type browserModel struct {
 	dir        string
 	entries    []os.DirEntry
+	tagCache   map[string]tagSummary
 	cursor     int
 	offset     int
 	selected   map[int]bool
@@ -58,12 +105,14 @@ func newBrowserModel(dir string) browserModel {
 	m := browserModel{
 		dir:      dir,
 		selected: make(map[int]bool),
+		tagCache: make(map[string]tagSummary),
 	}
 	entries, err := os.ReadDir(dir)
 	if err == nil {
 		entries = filterEntries(entries, false)
 		sortEntries(entries)
 		m.entries = entries
+		m.tagCache = loadTagCache(entries, dir)
 	}
 	return m
 }
@@ -79,6 +128,7 @@ func (m browserModel) changeDir(dir string) (browserModel, tea.Cmd) {
 	if err != nil {
 		m.dir = dir
 		m.entries = nil
+		m.tagCache = make(map[string]tagSummary)
 		m.cursor = 0
 		m.offset = 0
 		m.selected = make(map[int]bool)
@@ -88,6 +138,7 @@ func (m browserModel) changeDir(dir string) (browserModel, tea.Cmd) {
 	sortEntries(entries)
 	m.dir = dir
 	m.entries = entries
+	m.tagCache = loadTagCache(entries, dir)
 	m.cursor = 0
 	m.offset = 0
 	m.selected = make(map[int]bool)
@@ -287,7 +338,8 @@ func (m browserModel) View(width, height int) string {
 			styledName = name
 		}
 
-		line := prefix + styledName
+		nameWidth := lipgloss.Width(prefix + styledName)
+		line := prefix + styledName + m.tagColumn(entry.Name(), nameWidth, width)
 		if i == m.cursor {
 			line = styleCursor.Width(width).Render(line)
 		}
@@ -301,4 +353,36 @@ func (m browserModel) View(width, height int) string {
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+// tagColumn returns the styled tag info portion of a browser row, padded so
+// that name+tagColumn fills width. Returns "" when the screen is too narrow or
+// the file has no readable tags.
+func (m browserModel) tagColumn(name string, nameWidth, totalWidth int) string {
+	const minGap = 2
+	const minTagWidth = 12
+	available := totalWidth - nameWidth - minGap
+	if available < minTagWidth {
+		return ""
+	}
+	ext := strings.ToLower(filepath.Ext(name))
+	if ext != ".mp3" {
+		return ""
+	}
+	summary, ok := m.tagCache[name]
+	if !ok {
+		return ""
+	}
+	text := summary.display()
+	var styled string
+	if text == "" {
+		styled = styleNoTags.Render("—")
+	} else {
+		styled = styleTagInfo.Render(truncateRunes(text, available))
+	}
+	gap := available - lipgloss.Width(styled)
+	if gap < minGap {
+		gap = minGap
+	}
+	return strings.Repeat(" ", gap) + styled
 }

--- a/docs/design.md
+++ b/docs/design.md
@@ -41,21 +41,22 @@ claude.go            — Anthropic API call for smart tag lookup
 ## TUI Layout
 
 ```text
-┌─────────────────────────────────────────────┐
-│  FFEditor                  /home/user/Music │  ← header / current path
-├─────────────────────────────────────────────┤
-│  ▸ Albums/                                  │
-│    Tracks/                                  │
-│    cover.jpg                                │
-│    song.opus                                │
-│    demo.m4a                                 │  ← file browser (scrollable)
-│    notes.txt                                │
-│                                             │
-├─────────────────────────────────────────────┤
-│  [status / progress messages]               │  ← status bar
-├─────────────────────────────────────────────┤
-│  > _                                        │  ← command input
-└─────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│  FFEditor                             /home/user/Music       │ ← header
+├──────────────────────────────────────────────────────────────┤
+│  ▸ Albums/                                                   │
+│    Tracks/                                                   │
+│    cover.jpg                                                 │
+│    song.opus                                                 │
+│    demo.m4a                                                  │ ← browser
+│    tagged.mp3          The Beatles · Come Together           │
+│    untagged.mp3        —                                     │
+│    notes.txt                                                 │
+├──────────────────────────────────────────────────────────────┤
+│  [status / progress messages]                                │ ← status
+├──────────────────────────────────────────────────────────────┤
+│  > _                                                         │ ← command
+└──────────────────────────────────────────────────────────────┘
 ```
 
 ### Navigation
@@ -99,6 +100,20 @@ claude.go            — Anthropic API call for smart tag lookup
   `Ctrl+U` / `Ctrl+D` scroll half a screen at a time.
 - Press `?` to open an in-app help screen listing all keybindings.
   Any key dismisses it.
+
+#### Tag summary column
+
+For `.mp3` files, the browser shows a tag summary to the right of each
+filename. The summary displays `Artist · Title`; if only one field is
+present, just that value is shown. Files with no tag data show a dim
+`—` so untagged files are immediately visible. Non-`.mp3` audio files
+and non-audio entries show nothing in this column.
+
+The tag column is hidden automatically when the terminal is too narrow
+to show it without obscuring the filename (minimum 12 characters of
+available space required). Long summaries are truncated with `…`. The
+cache is refreshed whenever the directory changes or tags are saved, so
+the display stays current without a manual reload.
 
 ### 2. Audio Conversion
 

--- a/model.go
+++ b/model.go
@@ -141,12 +141,14 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.mode = modeBrowse
 		m.statusMsg = "Tags saved"
 		m.statusIsError = false
+		m.browser.tagCache = loadTagCache(m.browser.entries, m.browser.dir)
 		return m, nil
 
 	case tagBulkSavedMsg:
 		m.mode = modeBrowse
 		m.statusMsg = fmt.Sprintf("Tags updated (%d files)", msg.count)
 		m.statusIsError = false
+		m.browser.tagCache = loadTagCache(m.browser.entries, m.browser.dir)
 		return m, nil
 
 	case tagCancelledMsg:

--- a/styles.go
+++ b/styles.go
@@ -15,4 +15,6 @@ var (
 	styleTagDisabled = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 	styleCmdPrefix  = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
 	styleSymlink    = lipgloss.NewStyle().Foreground(lipgloss.Color("6"))
+	styleTagInfo    = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
+	styleNoTags     = lipgloss.NewStyle().Foreground(lipgloss.Color("238"))
 )


### PR DESCRIPTION
When viewing audio files in the Navigator, the tag information displays
to the left.  This allows the user to easily tell which files need
editing.

Updating design.md
