### PR TITLE
feat(browser): implement case-insensitive alphabetical sorting

### DIFF
--- a/browser.go
+++ b/browser.go
@@ -119,7 +119,11 @@ func newBrowserModel(dir string) browserModel {
 
 func sortEntries(entries []os.DirEntry) {
 	sort.SliceStable(entries, func(i, j int) bool {
-		return entries[i].IsDir() && !entries[j].IsDir()
+		iDir, jDir := entries[i].IsDir(), entries[j].IsDir()
+		if iDir != jDir {
+			return iDir
+		}
+		return strings.ToLower(entries[i].Name()) < strings.ToLower(entries[j].Name())
 	})
 }
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -85,7 +85,8 @@ claude.go            — Anthropic API call for smart tag lookup
 ### 1. File Browser
 
 - Lists files and directories in the current path.
-- Directories sort first, then files alphabetically.
+- Directories sort first, then files alphabetically
+  (case-insensitive).
 - Audio files (`.mp3`, `.opus`, `.m4a`, `.flac`, `.ogg`) are visually
   highlighted.
 - Dotfiles (dot-prefixed names) are hidden by default. Press `i` to


### PR DESCRIPTION
Update the entry sorting logic to provide a more intuitive file browser
experience. Previously, the browser only prioritized directories over
files without ordering the names within those groups.

The new logic maintains the directory-first priority but adds a
secondary sort criteria using case-insensitive alphabetical ordering.
This ensures that files and folders are consistently organized and
easier to locate regardless of their original filesystem order.
