### PR TITLE
feat(tags): implement batch smart tagging from file browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ directory if none is provided.
 | `Ctrl+A`      | Select all entries in current directory         |
 | `e`           | Edit ID3 tags for selected `.mp3` file(s)       |
 | `c`           | Convert selected audio files to `.mp3`          |
+| `Ctrl+T`      | Fill missing tags (smart tags) for selected `.mp3` |
 | `?`           | Show help screen                                |
 | `Ctrl+C`      | Cancel in-progress conversion                   |
 | `q`           | Quit                                            |
@@ -175,3 +176,18 @@ left unchanged on every file. The Title field is disabled in bulk
 mode (shown dimmed) to prevent accidental overwriting of individual
 track titles. Useful for stamping a shared Artist or Album across a
 whole album at once.
+
+## Smart Tags from Browser
+
+Press `Ctrl+T` in the file browser to automatically fill missing ID3
+tags for the selected `.mp3` file(s) without opening the tag editor.
+
+- Sends each file's basename to Claude Haiku, which guesses Artist,
+  Title, and Year from the filename.
+- Only **empty** fields are written. Any tag already set on the file
+  is left unchanged.
+- A spinner shows `Applying smart tags...` in the status bar while
+  the API calls run. Input is blocked during this time.
+- On completion: `Smart tags applied (N files)` shown in status bar.
+- Requires `ANTHROPIC_API_KEY` to be set in the environment. An error
+  is shown in the status bar if the key is missing or the API fails.

--- a/claude.go
+++ b/claude.go
@@ -25,6 +25,89 @@ type tagSearchResultMsg struct {
 
 type tagSearchErrMsg struct{ err error }
 
+// claudeTagResult holds the guessed tag values returned by the Claude API.
+type claudeTagResult struct {
+	Artist string
+	Title  string
+	Year   string
+}
+
+// callClaudeTagAPI sends a single filename to the Claude API and returns
+// guessed artist/title/year values.
+func callClaudeTagAPI(apiKey, filename string) (claudeTagResult, error) {
+	reqBody, err := json.Marshal(map[string]any{
+		"model":      "claude-haiku-4-5-20251001",
+		"max_tokens": 100,
+		"system":     `Extract music metadata from a filename. Reply ONLY with a JSON object with keys "artist", "title", "year". Use empty string if unknown. Parenthetical text containing words like "mix", "remix", "edit", "version", or "dub" is part of the title, not a separate field.`,
+		"messages": []map[string]string{
+			{"role": "user", "content": filepath.Base(filename)},
+		},
+	})
+	if err != nil {
+		return claudeTagResult{}, err
+	}
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	req, err := http.NewRequest("POST", claudeAPIURL, bytes.NewReader(reqBody))
+	if err != nil {
+		return claudeTagResult{}, err
+	}
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", "2023-06-01")
+	req.Header.Set("content-type", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return claudeTagResult{}, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return claudeTagResult{}, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return claudeTagResult{}, fmt.Errorf("API error %d: %s", resp.StatusCode, body)
+	}
+
+	// Parse Messages API envelope.
+	var envelope struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return claudeTagResult{}, err
+	}
+	if len(envelope.Content) == 0 {
+		return claudeTagResult{}, errors.New("empty response from API")
+	}
+
+	text := envelope.Content[0].Text
+	// Extract the JSON object robustly.
+	start := strings.Index(text, "{")
+	end := strings.LastIndex(text, "}")
+	if start < 0 || end < 0 || end < start {
+		return claudeTagResult{}, fmt.Errorf("no JSON in response: %s", text)
+	}
+	jsonStr := text[start : end+1]
+
+	var result struct {
+		Artist string `json:"artist"`
+		Title  string `json:"title"`
+		Year   string `json:"year"`
+	}
+	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
+		return claudeTagResult{}, err
+	}
+
+	return claudeTagResult{
+		Artist: result.Artist,
+		Title:  result.Title,
+		Year:   result.Year,
+	}, nil
+}
+
 func claudeGuessTagsCmd(filename string) tea.Cmd {
 	return func() tea.Msg {
 		apiKey := os.Getenv("ANTHROPIC_API_KEY")
@@ -32,69 +115,8 @@ func claudeGuessTagsCmd(filename string) tea.Cmd {
 			return tagSearchErrMsg{errors.New("ANTHROPIC_API_KEY not set")}
 		}
 
-		reqBody, err := json.Marshal(map[string]any{
-			"model":      "claude-haiku-4-5-20251001",
-			"max_tokens": 100,
-			"system":     `Extract music metadata from a filename. Reply ONLY with a JSON object with keys "artist", "title", "year". Use empty string if unknown. Parenthetical text containing words like "mix", "remix", "edit", "version", or "dub" is part of the title, not a separate field.`,
-			"messages": []map[string]string{
-				{"role": "user", "content": filepath.Base(filename)},
-			},
-		})
+		result, err := callClaudeTagAPI(apiKey, filename)
 		if err != nil {
-			return tagSearchErrMsg{err}
-		}
-
-		client := &http.Client{Timeout: 15 * time.Second}
-		req, err := http.NewRequest("POST", claudeAPIURL, bytes.NewReader(reqBody))
-		if err != nil {
-			return tagSearchErrMsg{err}
-		}
-		req.Header.Set("x-api-key", apiKey)
-		req.Header.Set("anthropic-version", "2023-06-01")
-		req.Header.Set("content-type", "application/json")
-
-		resp, err := client.Do(req)
-		if err != nil {
-			return tagSearchErrMsg{err}
-		}
-		defer resp.Body.Close()
-
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return tagSearchErrMsg{err}
-		}
-		if resp.StatusCode != http.StatusOK {
-			return tagSearchErrMsg{fmt.Errorf("API error %d: %s", resp.StatusCode, body)}
-		}
-
-		// Parse Messages API envelope.
-		var envelope struct {
-			Content []struct {
-				Text string `json:"text"`
-			} `json:"content"`
-		}
-		if err := json.Unmarshal(body, &envelope); err != nil {
-			return tagSearchErrMsg{err}
-		}
-		if len(envelope.Content) == 0 {
-			return tagSearchErrMsg{errors.New("empty response from API")}
-		}
-
-		text := envelope.Content[0].Text
-		// Extract the JSON object robustly.
-		start := strings.Index(text, "{")
-		end := strings.LastIndex(text, "}")
-		if start < 0 || end < 0 || end < start {
-			return tagSearchErrMsg{fmt.Errorf("no JSON in response: %s", text)}
-		}
-		jsonStr := text[start : end+1]
-
-		var result struct {
-			Artist string `json:"artist"`
-			Title  string `json:"title"`
-			Year   string `json:"year"`
-		}
-		if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
 			return tagSearchErrMsg{err}
 		}
 

--- a/claude_test.go
+++ b/claude_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	id3 "github.com/bogem/id3v2/v2"
 )
 
 func TestClaudeGuessTagsCmd_NoAPIKey(t *testing.T) {
@@ -90,5 +92,146 @@ func TestClaudeGuessTagsCmd_APIError(t *testing.T) {
 	msg := claudeGuessTagsCmd("file.mp3")()
 	if _, ok := msg.(tagSearchErrMsg); !ok {
 		t.Fatalf("expected tagSearchErrMsg, got %T", msg)
+	}
+}
+
+func TestSmartTagCmd_NoAPIKey(t *testing.T) {
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	dir := t.TempDir()
+	path := makeMP3(t, dir, "test.mp3")
+	msg := smartTagCmd([]string{path})()
+	if _, ok := msg.(smartTagErrMsg); !ok {
+		t.Fatalf("expected smartTagErrMsg, got %T", msg)
+	}
+}
+
+func TestSmartTagCmd_FillsMissingFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"content": [{"type":"text","text":"{\"artist\":\"The Beatles\",\"title\":\"Hey Jude\",\"year\":\"1968\"}"}]
+		}`))
+	}))
+	defer srv.Close()
+
+	orig := claudeAPIURL
+	claudeAPIURL = srv.URL
+	defer func() { claudeAPIURL = orig }()
+
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	dir := t.TempDir()
+	path := makeMP3(t, dir, "hey-jude-beatles-1968.mp3")
+
+	msg := smartTagCmd([]string{path})()
+	result, ok := msg.(smartTagDoneMsg)
+	if !ok {
+		t.Fatalf("expected smartTagDoneMsg, got %T", msg)
+	}
+	if result.count != 1 {
+		t.Errorf("count: got %d, want 1", result.count)
+	}
+
+	tag, err := id3.Open(path, id3.Options{Parse: true})
+	if err != nil {
+		t.Fatalf("re-open: %v", err)
+	}
+	defer tag.Close()
+	if got := tag.Title(); got != "Hey Jude" {
+		t.Errorf("title: got %q, want %q", got, "Hey Jude")
+	}
+	if got := tag.Artist(); got != "The Beatles" {
+		t.Errorf("artist: got %q, want %q", got, "The Beatles")
+	}
+	if got := tag.Year(); got != "1968" {
+		t.Errorf("year: got %q, want %q", got, "1968")
+	}
+}
+
+func TestSmartTagCmd_DoesNotOverwriteExistingFields(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{
+			"content": [{"type":"text","text":"{\"artist\":\"Wrong Artist\",\"title\":\"Wrong Title\",\"year\":\"2000\"}"}]
+		}`))
+	}))
+	defer srv.Close()
+
+	orig := claudeAPIURL
+	claudeAPIURL = srv.URL
+	defer func() { claudeAPIURL = orig }()
+
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	dir := t.TempDir()
+	path := makeMP3(t, dir, "test.mp3")
+
+	// Pre-populate artist only; title and year are missing.
+	tag, err := id3.Open(path, id3.Options{Parse: true})
+	if err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	tag.SetArtist("Correct Artist")
+	if err := tag.Save(); err != nil {
+		tag.Close()
+		t.Fatalf("setup save: %v", err)
+	}
+	tag.Close()
+
+	msg := smartTagCmd([]string{path})()
+	if _, ok := msg.(smartTagDoneMsg); !ok {
+		t.Fatalf("expected smartTagDoneMsg, got %T", msg)
+	}
+
+	tag, err = id3.Open(path, id3.Options{Parse: true})
+	if err != nil {
+		t.Fatalf("re-open: %v", err)
+	}
+	defer tag.Close()
+
+	// Artist must be unchanged.
+	if got := tag.Artist(); got != "Correct Artist" {
+		t.Errorf("artist: got %q, want %q (must not be overwritten)", got, "Correct Artist")
+	}
+	// Title and year should be filled by the API.
+	if got := tag.Title(); got != "Wrong Title" {
+		t.Errorf("title: got %q, want %q", got, "Wrong Title")
+	}
+	if got := tag.Year(); got != "2000" {
+		t.Errorf("year: got %q, want %q", got, "2000")
+	}
+}
+
+func TestSmartTagCmd_SkipsFullyTaggedFiles(t *testing.T) {
+	apiCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCalled = true
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"content": [{"type":"text","text":"{}"}]}`))
+	}))
+	defer srv.Close()
+
+	orig := claudeAPIURL
+	claudeAPIURL = srv.URL
+	defer func() { claudeAPIURL = orig }()
+
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	dir := t.TempDir()
+	path := makeMP3(t, dir, "test.mp3")
+	writeTag(t, path, "Title", "Artist", "", "2001")
+
+	msg := smartTagCmd([]string{path})()
+	result, ok := msg.(smartTagDoneMsg)
+	if !ok {
+		t.Fatalf("expected smartTagDoneMsg, got %T", msg)
+	}
+	if result.count != 0 {
+		t.Errorf("count: got %d, want 0 (file already fully tagged)", result.count)
+	}
+	if apiCalled {
+		t.Error("API should not be called for fully-tagged files")
 	}
 }

--- a/commands.go
+++ b/commands.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 
+	id3 "github.com/bogem/id3v2/v2"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
@@ -14,12 +16,16 @@ var knownCommands = []string{"cd", "convert", "edit", "q", "tag"}
 type cmdHandler func(model, []string) (model, tea.Cmd)
 
 var commandHandlers = map[string]cmdHandler{
-	"q":       cmdQuit,
-	"cd":      cmdCd,
-	"convert": cmdConvert,
-	"tag":     cmdTagEdit,
-	"edit":    cmdTagEdit,
+	"q":          cmdQuit,
+	"cd":         cmdCd,
+	"convert":    cmdConvert,
+	"tag":        cmdTagEdit,
+	"edit":       cmdTagEdit,
+	"smart-tag":  cmdSmartTag,
 }
+
+type smartTagDoneMsg struct{ count int }
+type smartTagErrMsg struct{ err error }
 
 func cmdQuit(m model, _ []string) (model, tea.Cmd) {
 	return m, tea.Quit
@@ -93,6 +99,82 @@ func cmdTagEdit(m model, _ []string) (model, tea.Cmd) {
 		return m, nil
 	}
 	return m, func() tea.Msg { return execTagMsg{mp3s} }
+}
+
+func cmdSmartTag(m model, _ []string) (model, tea.Cmd) {
+	entries := m.browser.selectedEntries()
+	var mp3s []string
+	for _, e := range entries {
+		if !e.IsDir() && strings.ToLower(filepath.Ext(e.Name())) == ".mp3" {
+			mp3s = append(mp3s, filepath.Join(m.browser.dir, e.Name()))
+		}
+	}
+	if len(mp3s) == 0 {
+		m.statusMsg = "No .mp3 files selected"
+		m.statusIsError = true
+		return m, nil
+	}
+	m.mode = modeSmartTagging
+	m.spinnerFrame = 0
+	return m, tea.Batch(smartTagCmd(mp3s), spinnerTick())
+}
+
+// smartTagCmd fills missing ID3 tags (artist, title, year) for each file
+// using the Claude API, without overwriting fields that are already set.
+func smartTagCmd(files []string) tea.Cmd {
+	return func() tea.Msg {
+		apiKey := os.Getenv("ANTHROPIC_API_KEY")
+		if apiKey == "" {
+			return smartTagErrMsg{errors.New("ANTHROPIC_API_KEY not set")}
+		}
+
+		count := 0
+		for _, file := range files {
+			tag, err := id3.Open(file, id3.Options{Parse: true})
+			if err != nil {
+				continue
+			}
+			existingTitle := tag.Title()
+			existingArtist := tag.Artist()
+			existingYear := tag.Year()
+			tag.Close()
+
+			// Skip files where all three fields are already populated.
+			if existingTitle != "" && existingArtist != "" && existingYear != "" {
+				continue
+			}
+
+			guessed, err := callClaudeTagAPI(apiKey, file)
+			if err != nil {
+				continue
+			}
+
+			tag, err = id3.Open(file, id3.Options{Parse: true})
+			if err != nil {
+				continue
+			}
+			changed := false
+			if existingTitle == "" && guessed.Title != "" {
+				tag.SetTitle(guessed.Title)
+				changed = true
+			}
+			if existingArtist == "" && guessed.Artist != "" {
+				tag.SetArtist(guessed.Artist)
+				changed = true
+			}
+			if existingYear == "" && guessed.Year != "" {
+				tag.SetYear(guessed.Year)
+				changed = true
+			}
+			if changed {
+				tag.Save()
+				count++
+			}
+			tag.Close()
+		}
+
+		return smartTagDoneMsg{count}
+	}
 }
 
 type cmdbarModel struct {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,7 @@ const (
     modeTagSaving
     modeTagSearching
     modeHelp
+    modeSmartTagging
 )
 
 type model struct {
@@ -98,14 +99,15 @@ type model struct {
 
 **Message routing rules:**
 
-| `m.mode`           | Routed to | Notes                               |
+| `m.mode`           | To        | Notes                               |
 |--------------------|-----------|-------------------------------------|
-| `modeBrowse`       | `browser` | `:` → `modeCommand`; `q` quits; `c` quick-convert; `e` quick-tag |
+| `modeBrowse`       | `browser` | `:` cmd; `q` quit; `c`/`e`/`Ctrl+T` dispatch |
 | `modeCommand`      | `cmdbar`  | `Enter` dispatches; `Esc` exits     |
 | `modeTag`          | `tagger`  | `Ctrl+T` searches; `Ctrl+S` saves   |
 | `modeTagSaving`    | —         | Input blocked; spinner shown        |
 | `modeTagSearching` | —         | Input blocked; spinner shown        |
 | `modeHelp`         | —         | Any key returns to `modeBrowse`     |
+| `modeSmartTagging` | —         | Input blocked; spinner; browser view |
 
 All modes receive `tea.WindowSizeMsg` for responsive layout. Custom
 messages (conversion progress, completion, errors) are handled at the
@@ -129,8 +131,8 @@ browser         → height - 4 lines (fills remaining space)
   OR tagger     → same region when mode ∈ {modeTag, modeTagSaving,
                   modeTagSearching}
   OR help       → same region when mode == modeHelp
-status bar      → 1 line (spinner shown during modeTagSaving /
-                  modeTagSearching)
+status bar      → 1 line (spinner shown during modeTagSaving,
+                  modeTagSearching, modeSmartTagging)
 command bar     → 1 line (visible in all modes, editable in
                   modeCommand)
 ```
@@ -232,6 +234,7 @@ available; shown as `—` for untagged files).
 | `i`          | Toggle `showHidden`; reload dir via `changeDir`    |
 | `Space`      | Toggle `selected[cursor]`, advance cursor          |
 | `Ctrl+A`     | Set `selected[i] = true` for all `i` in entries   |
+| `Ctrl+T`     | Dispatch `smart-tag` command                       |
 
 On directory change, emit a custom `dirChangedMsg{path}` so the root
 model can update the header.
@@ -520,14 +523,40 @@ one match. No cycling.
 
 **Dispatch table** (handled in `model.go`'s `dispatchCommand`):
 
-| Command   | Validation                        | Behaviour                  |
-|-----------|-----------------------------------|----------------------------|
-| `convert` | ffmpeg available; has targets     | Emits `execConvertMsg`     |
-| `tag`     | Selection has `.mp3` files        | Emits `execTagMsg`         |
-| `cd`      | Path is an existing directory     | Calls `browser.changeDir`  |
-| `q`       | —                                 | Returns `tea.Quit`         |
+| Command     | Validation                    | Behaviour                       |
+|-------------|-------------------------------|---------------------------------|
+| `convert`   | ffmpeg available; has targets | Emits `execConvertMsg`          |
+| `tag`       | Selection has `.mp3` files    | Emits `execTagMsg`              |
+| `cd`        | Path is an existing directory | Calls `browser.changeDir`       |
+| `q`         | —                             | Returns `tea.Quit`              |
+| `smart-tag` | Selection has `.mp3` files    | Sets `modeSmartTagging`; Cmd    |
+
+`smart-tag` is key-only (`Ctrl+T` in `modeBrowse`) and is not in
+`knownCommands`, so it does not appear in tab completion.
 
 Unknown commands → set `statusMsg` to `"Unknown command: foo"`.
+
+**Smart tag messages (navigator flow, defined in `commands.go`):**
+
+```go
+type smartTagDoneMsg struct{ count int }
+type smartTagErrMsg  struct{ err error }
+```
+
+**`smartTagCmd(files []string) tea.Cmd`:**
+
+Runs in a goroutine:
+
+1. Checks `ANTHROPIC_API_KEY`; returns `smartTagErrMsg` if unset.
+2. For each file:
+   a. Opens the ID3 tag and reads Title, Artist, Year.
+   b. Skips the file if all three are already non-empty (no API
+      call).
+   c. Calls `callClaudeTagAPI` to guess missing values.
+   d. Opens the file again and writes only the fields that were
+      empty and the API returned a non-empty value for.
+3. Returns `smartTagDoneMsg{count}` where `count` is the number of
+   files that were actually changed.
 
 On `Enter`, the command bar parses, dispatches via `dispatchCommand`,
 clears `input`, sets `active = false`, and returns focus to
@@ -535,52 +564,50 @@ clears `input`, sets `active = false`, and returns focus to
 
 ### 2.7 `claude.go` — Smart Tag Lookup
 
-This module contains no TUI code. It exposes one `tea.Cmd` factory and
-the two message types it returns.
+This module contains no TUI or ID3 code. It exposes the API helper
+and the two `tea.Cmd` factories that call it.
 
-**Message types:**
+**Message types (tag editor flow):**
 
 ```go
 type tagSearchResultMsg struct{ artist, title, year string }
 type tagSearchErrMsg    struct{ err error }
 ```
 
+**`callClaudeTagAPI(apiKey, filename string) (claudeTagResult, error)`:**
+
+Low-level helper shared by both `tea.Cmd` factories:
+
+1. Builds a JSON request body for the Anthropic Messages API:
+   - Model: `claude-haiku-4-5-20251001`; `max_tokens`: 100.
+   - System prompt: reply with only
+     `{"artist":"…","title":"…","year":"…"}`.
+   - User message: `filepath.Base(filename)` (basename only).
+2. POSTs to `claudeAPIURL` (package-level var, default
+   `https://api.anthropic.com/v1/messages`) using `net/http` with
+   a 15-second timeout.
+3. Parses the Messages API envelope; extracts the first `{…}` from
+   `content[0].text` to tolerate prose wrapping.
+4. Returns `claudeTagResult{Artist, Title, Year}` or an error.
+
 **`claudeGuessTagsCmd(filename string) tea.Cmd`:**
 
-Returns a `tea.Cmd` that runs in a goroutine and:
+Thin wrapper: checks `ANTHROPIC_API_KEY`, calls
+`callClaudeTagAPI`, returns `tagSearchResultMsg` or
+`tagSearchErrMsg`. Used by the tag editor (`modeTagSearching`).
 
-1. Reads `ANTHROPIC_API_KEY` from the environment. Returns
-   `tagSearchErrMsg` immediately if unset.
-2. Builds a JSON request body for the Anthropic Messages API:
-   - Model: `claude-haiku-4-5-20251001`
-   - `max_tokens`: 100
-   - System prompt instructs the model to reply with only a JSON
-     object `{"artist":"…","title":"…","year":"…"}`, and notes that
-     parenthetical text containing words like "mix", "remix", "edit",
-     "version", or "dub" is part of the title.
-   - User message: `filepath.Base(filename)` (basename only — no
-     path leakage).
-3. POSTs to `claudeAPIURL` (package-level var, default
-   `https://api.anthropic.com/v1/messages`) using `net/http` with a
-   15-second timeout. Headers: `x-api-key`, `anthropic-version:
-   2023-06-01`, `content-type: application/json`.
-4. Parses the Messages API envelope, extracts `content[0].text`.
-5. Finds the first `{` and last `}` in the text and unmarshals that
-   substring — this tolerates prose wrapping the JSON.
-6. Returns `tagSearchResultMsg` or `tagSearchErrMsg`.
+**Root model integration (tag editor):**
+
+When `Ctrl+T` is pressed in `modeTag` with a single file open, the
+root model transitions to `modeTagSearching`, starts the spinner,
+and dispatches `claudeGuessTagsCmd` as a `tea.Batch` alongside
+`spinnerTick`. On `tagSearchResultMsg`, blank tag fields are
+pre-filled and mode returns to `modeTag`. On `tagSearchErrMsg`, the
+error is shown in the status bar and mode returns to `modeTag`.
 
 The `claudeAPIURL` variable is overridable in tests to point at an
 `httptest.Server`, allowing the full request/response path to be
 exercised without a real API key.
-
-**Root model integration:**
-
-When `Ctrl+T` is pressed in `modeTag` with a single file open, the
-root model transitions to `modeTagSearching`, starts the spinner, and
-dispatches `claudeGuessTagsCmd` as a `tea.Batch` alongside
-`spinnerTick`. On `tagSearchResultMsg`, blank tag fields are
-pre-filled and mode returns to `modeTag`. On `tagSearchErrMsg`, the
-error is shown in the status bar and mode returns to `modeTag`.
 
 ## 3. Message Flow Diagrams
 
@@ -634,7 +661,30 @@ Root.Update receives       → mode = modeTag
                            → statusMsg = "Smart tag error: …"
 ```
 
-### 3.4 Conversion Cancellation
+### 3.4 Smart Tags from Browser
+
+```text
+User presses Ctrl+T        → dispatchCommand(m, "smart-tag", nil)
+cmdSmartTag called         → filter selected entries for .mp3 files
+                           → mode = modeSmartTagging
+                           → spinnerTick + smartTagCmd batched
+Spinner ticks              → spinnerFrame advances
+                           → "Applying smart tags..." shown in status
+For each file:             → read existing tags
+  if all 3 fields set      → skip (no API call)
+  else                     → callClaudeTagAPI(apiKey, file)
+                           → write only empty fields back to file
+smartTagCmd returns        → smartTagDoneMsg{count}
+Root.Update receives       → mode = modeBrowse
+  smartTagDoneMsg          → tagCache refreshed
+                           → statusMsg = "Smart tags applied (N files)"
+
+  (on API key missing      → smartTagErrMsg{err}
+   or unrecoverable err)   → mode = modeBrowse
+                           → statusMsg = "Smart tag error: …"
+```
+
+### 3.5 Conversion Cancellation
 
 ```text
 Conversion in progress     → convertFile goroutine running ffmpeg
@@ -679,8 +729,10 @@ arrive sequentially, and no locks are needed on model state.
 | Invalid tag file       | `id3v2.Open`          | Status bar; back to browse |
 | Unknown command        | `dispatchCommand`     | `"Unknown command: X"`     |
 | cd to bad dir          | `dispatchCommand`     | `"Not a directory: X"`     |
-| API key unset          | `claudeGuessTagsCmd`  | `"Smart tag error: …"`     |
-| Anthropic API error    | `claudeGuessTagsCmd`  | `"Smart tag error: …"`     |
+| API key unset       | `claudeGuessTagsCmd` | `"Smart tag error: …"` (editor) |
+| Anthropic API error | `claudeGuessTagsCmd` | `"Smart tag error: …"` (editor) |
+| API key unset       | `smartTagCmd`        | `"Smart tag error: …"` (browser) |
+| API error per file  | `smartTagCmd`        | skip file, continue queue        |
 
 Errors never cause a panic or program exit. All errors are surfaced
 through `statusMsg` with `statusIsError = true` (rendered in red).
@@ -776,6 +828,10 @@ navigation simple. Extracting packages (e.g., `pkg/convert`,
 |             | response is parsed into `tagSearchResultMsg`;     |
 |             | JSON embedded in prose is extracted correctly;    |
 |             | non-200 HTTP status returns `tagSearchErrMsg`.    |
+|             | `smartTagCmd`: missing key returns               |
+|             | `smartTagErrMsg`; successful call fills missing   |
+|             | fields; existing fields are not overwritten;      |
+|             | fully-tagged files skip the API call entirely.    |
 |             | `claudeAPIURL` is a package-level var overridden  |
 |             | in tests to avoid real network calls.             |
 | TUI         | Manual testing. Bubble Tea's `tea.Test` helpers   |

--- a/docs/design.md
+++ b/docs/design.md
@@ -76,6 +76,7 @@ claude.go            — Anthropic API call for smart tag lookup
 | `Ctrl+A`      | Select all entries in current directory         |
 | `e`           | Edit ID3 tags for selected `.mp3` file(s)       |
 | `c`           | Convert selected audio files to `.mp3`          |
+| `Ctrl+T`      | Fill missing tags (smart tags), no editor       |
 | `?`           | Show help screen (any key to dismiss)           |
 | `:`           | Focus command bar                               |
 | `Ctrl+C`      | Cancel in-progress conversion (stay in app)     |
@@ -241,6 +242,23 @@ accidentally overwriting individual track titles. Useful for setting
 a shared album or artist across multiple tracks. The Files box lists
 all selected filenames. Tab completion tokens are drawn from all
 filenames combined.
+
+### 4. Smart Tags from Browser
+
+Press `Ctrl+T` in the file browser to fill missing ID3 tags for the
+selected `.mp3` file(s) without opening the tag editor. Works on a
+single file (cursor) or any number of space-selected files.
+
+- For each file, the basename is sent to Claude Haiku, which guesses
+  Artist, Title, and Year.
+- Only fields that are currently **empty** are written back. Existing
+  tag values are never overwritten.
+- Files where Artist, Title, and Year are all already set are skipped
+  entirely — no API call is made for them.
+- A `Applying smart tags...` spinner blocks input during the operation.
+- On completion, the status bar shows `Smart tags applied (N files)`
+  and the tag summary column in the browser refreshes automatically.
+- Requires `ANTHROPIC_API_KEY`. Shows an error if unset.
 
 ## Commands
 

--- a/help.go
+++ b/help.go
@@ -24,6 +24,7 @@ func helpView(width, height int) string {
 		"  Commands",
 		"    e           edit tags",
 		"    c           convert file(s)",
+		"    ctrl+t      fill missing tags (smart tags)",
 		"    :cd <dir>   change directory",
 		"    q           quit",
 		"",

--- a/keys.go
+++ b/keys.go
@@ -9,7 +9,7 @@ func handleKeyMsg(m model, msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return updateBrowseMode(m, msg)
 	case modeTag:
 		return updateTagMode(m, msg)
-	case modeTagSaving, modeTagSearching:
+	case modeTagSaving, modeTagSearching, modeSmartTagging:
 		return m, nil
 	case modeHelp:
 		return updateHelpMode(m, msg)
@@ -40,6 +40,8 @@ func updateBrowseMode(m model, msg tea.KeyMsg) (model, tea.Cmd) {
 		return dispatchCommand(m, "edit", nil)
 	case "c":
 		return dispatchCommand(m, "convert", nil)
+	case "ctrl+t":
+		return dispatchCommand(m, "smart-tag", nil)
 	case "?":
 		m.mode = modeHelp
 		return m, nil

--- a/model.go
+++ b/model.go
@@ -18,6 +18,7 @@ const (
 	modeTagSaving
 	modeTagSearching
 	modeHelp
+	modeSmartTagging
 )
 
 type spinnerTickMsg struct{}
@@ -96,7 +97,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case spinnerTickMsg:
-		if m.mode == modeTagSaving || m.mode == modeTagSearching {
+		if m.mode == modeTagSaving || m.mode == modeTagSearching || m.mode == modeSmartTagging {
 			m.spinnerFrame = (m.spinnerFrame + 1) % len(spinnerFrames)
 			return m, spinnerTick()
 		}
@@ -147,6 +148,19 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusIsError = true
 		return m, nil
 
+	case smartTagDoneMsg:
+		m.mode = modeBrowse
+		m.statusMsg = fmt.Sprintf("Smart tags applied (%d files)", msg.count)
+		m.statusIsError = false
+		m.browser.tagCache = loadTagCache(m.browser.entries, m.browser.dir)
+		return m, nil
+
+	case smartTagErrMsg:
+		m.mode = modeBrowse
+		m.statusMsg = "Smart tag error: " + msg.err.Error()
+		m.statusIsError = true
+		return m, nil
+
 	case dirReadErrMsg:
 		m.statusMsg = "Cannot read directory: " + msg.err.Error()
 		m.statusIsError = true
@@ -190,12 +204,13 @@ func (m model) View() string {
 	default:
 		browserView = m.browser.View(m.width, browserHeight)
 	}
-
 	var statusLine string
 	if m.mode == modeTagSaving {
 		statusLine = styleStatusOk.Render(spinnerFrames[m.spinnerFrame] + " Saving...")
 	} else if m.mode == modeTagSearching {
 		statusLine = styleStatusOk.Render(spinnerFrames[m.spinnerFrame] + " Searching...")
+	} else if m.mode == modeSmartTagging {
+		statusLine = styleStatusOk.Render(spinnerFrames[m.spinnerFrame] + " Applying smart tags...")
 	} else if m.statusIsError {
 		statusLine = styleStatusErr.Render(m.statusMsg)
 	} else if m.statusMsg != "" {


### PR DESCRIPTION
Introduce a "Smart Tag" feature accessible via `Ctrl+T` in the file
browser. This allows users to automatically populate missing ID3 tags
(Artist, Title, Year) for selected .mp3 files using the Claude API
without entering the manual tag editor.

The implementation refactors the existing Claude API logic into a
reusable helper and introduces a new `modeSmartTagging` state. To
conserve API tokens and prevent data loss, the command only fills
fields that are currently empty and skips files that are already
fully tagged.

Key changes:
- Added `Ctrl+T` keybinding and `smart-tag` command.
- Refactored `claude.go` to expose `callClaudeTagAPI`.
- Implemented asynchronous batch processing with a status bar spinner.
- Updated architecture and design documentation.
- Added unit tests for tag preservation and API error handling.
