### PR TITLE
feat(tags): FLAC tag editing (#39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ directory if none is provided.
 | `i`           | Toggle hidden files (dotfiles)                  |
 | `Space`       | Toggle selection (advances cursor)              |
 | `Ctrl+A`      | Select all entries in current directory         |
-| `e`           | Edit ID3 tags for selected `.mp3` file(s)       |
+| `e`           | Edit tags for selected `.mp3` / `.flac` file(s) |
 | `c`           | Convert selected audio files to `.mp3`          |
-| `Ctrl+T`      | Fill missing tags (smart tags) for selected `.mp3` |
+| `Ctrl+T`      | Fill missing tags (smart tags) for selected files |
 | `?`           | Show help screen                                |
 | `Ctrl+C`      | Cancel in-progress conversion                   |
 | `q`           | Quit                                            |
@@ -72,7 +72,7 @@ execute, or `Esc` to cancel.
 
 | Command      | Description                                      |
 |--------------|--------------------------------------------------|
-| `:edit`      | Edit ID3 tags for selected `.mp3` file(s)        |
+| `:edit`      | Edit tags for selected `.mp3` / `.flac` file(s)  |
 | `:tag`       | Synonym for `:edit`                              |
 | `:convert`   | Convert selected audio files to `.mp3`           |
 | `:cd <path>` | Navigate to a directory                          |
@@ -127,10 +127,11 @@ the originals. Source files are not deleted.
   normally and `:convert` shows an error in the status bar.
 - **Supported Formats**: `.opus`, `.m4a`, `.ogg`
 
-## ID3 Tag Editing
+## Tag Editing
 
-Select one or more `.mp3` files and press `e` (or run `:edit` / `:tag`)
-to open the tag editor.
+Select one or more `.mp3` or `.flac` files and press `e` (or run
+`:edit` / `:tag`) to open the tag editor. MP3 files use ID3 tags;
+FLAC files use Vorbis Comments — both expose the same six fields.
 
 ```text
 ╭─ Files ───────────────────────────────╮
@@ -169,7 +170,8 @@ fields are pre-filled with the result; non-blank fields are left
 unchanged. A spinner shows in the status bar while the model runs.
 Requires `ANTHROPIC_API_KEY` to be set.
 
-**Bulk tagging**: select multiple `.mp3` files before running `:edit`.
+**Bulk tagging**: select multiple `.mp3` or `.flac` files (or a mix)
+before running `:edit`.
 Fields shared by every selected file are pre-filled; differing fields
 start blank. Only fields you fill in are written — blank fields are
 left unchanged on every file. The Title field is disabled in bulk
@@ -179,8 +181,9 @@ whole album at once.
 
 ## Smart Tags from Browser
 
-Press `Ctrl+T` in the file browser to automatically fill missing ID3
-tags for the selected `.mp3` file(s) without opening the tag editor.
+Press `Ctrl+T` in the file browser to automatically fill missing tags
+for the selected `.mp3` or `.flac` file(s) without opening the tag
+editor.
 
 - Sends each file's basename to Claude Haiku, which guesses Artist,
   Title, and Year from the filename.

--- a/tagger_test.go
+++ b/tagger_test.go
@@ -361,3 +361,97 @@ func TestFLACTagSummaryInBrowser(t *testing.T) {
 		t.Errorf("title: got %q, want %q", summary.title, "Test Song")
 	}
 }
+
+func TestFLACAllFieldsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := makeFlac(t, dir, "all-fields.flac")
+
+	m, err := newTaggerModel([]string{path})
+	if err != nil {
+		t.Fatalf("newTaggerModel: %v", err)
+	}
+
+	m.fields[0].value = "Round Trip Title"
+	m.fields[1].value = "Round Trip Artist"
+	m.fields[2].value = "Round Trip Album"
+	m.fields[3].value = "2024"
+	m.fields[4].value = "7"
+	m.fields[5].value = "Classical"
+
+	if _, ok := m.saveTags()().(tagSavedMsg); !ok {
+		t.Fatal("expected tagSavedMsg")
+	}
+
+	data, err := readFLACTags(path)
+	if err != nil {
+		t.Fatalf("readFLACTags: %v", err)
+	}
+	if data.Title != "Round Trip Title" {
+		t.Errorf("title: got %q, want %q", data.Title, "Round Trip Title")
+	}
+	if data.Artist != "Round Trip Artist" {
+		t.Errorf("artist: got %q, want %q", data.Artist, "Round Trip Artist")
+	}
+	if data.Album != "Round Trip Album" {
+		t.Errorf("album: got %q, want %q", data.Album, "Round Trip Album")
+	}
+	if data.Year != "2024" {
+		t.Errorf("year: got %q, want %q", data.Year, "2024")
+	}
+	if data.Track != "7" {
+		t.Errorf("track: got %q, want %q", data.Track, "7")
+	}
+	if data.Genre != "Classical" {
+		t.Errorf("genre: got %q, want %q", data.Genre, "Classical")
+	}
+}
+
+// TestFLACWriteMaskPreservesOtherFields verifies that writing one field
+// does not destroy other existing Vorbis Comment entries.
+func TestFLACWriteMaskPreservesOtherFields(t *testing.T) {
+	dir := t.TempDir()
+	path := makeFlac(t, dir, "preserve.flac")
+	writeFlacTags(t, path, map[string]string{
+		flacvorbis.FIELD_TITLE:       "Keep Me",
+		flacvorbis.FIELD_ARTIST:      "Also Keep",
+		flacvorbis.FIELD_ALBUM:       "Keep Album",
+		flacvorbis.FIELD_DATE:        "2000",
+		flacvorbis.FIELD_TRACKNUMBER: "3",
+		flacvorbis.FIELD_GENRE:       "Jazz",
+	})
+
+	m, err := newTaggerModel([]string{path})
+	if err != nil {
+		t.Fatalf("newTaggerModel: %v", err)
+	}
+
+	// Change only Artist.
+	m.fields[1].value = "New Artist"
+
+	if _, ok := m.saveTags()().(tagSavedMsg); !ok {
+		t.Fatal("expected tagSavedMsg")
+	}
+
+	data, err := readFLACTags(path)
+	if err != nil {
+		t.Fatalf("readFLACTags: %v", err)
+	}
+	if data.Title != "Keep Me" {
+		t.Errorf("title: got %q, want %q", data.Title, "Keep Me")
+	}
+	if data.Artist != "New Artist" {
+		t.Errorf("artist: got %q, want %q", data.Artist, "New Artist")
+	}
+	if data.Album != "Keep Album" {
+		t.Errorf("album: got %q, want %q", data.Album, "Keep Album")
+	}
+	if data.Year != "2000" {
+		t.Errorf("year: got %q, want %q", data.Year, "2000")
+	}
+	if data.Track != "3" {
+		t.Errorf("track: got %q, want %q", data.Track, "3")
+	}
+	if data.Genre != "Jazz" {
+		t.Errorf("genre: got %q, want %q", data.Genre, "Jazz")
+	}
+}


### PR DESCRIPTION
## Summary

- Update README to document FLAC alongside MP3 in all tag-editing
  sections (key bindings table, command bar table, Tag Editing section
  header, bulk tagging paragraph, Smart Tags section)
- Add `TestFLACAllFieldsRoundTrip` — exercises all six Vorbis Comment
  fields (Title, Artist, Album, DATE, TRACKNUMBER, Genre) through the
  tagger's save/read cycle
- Add `TestFLACWriteMaskPreservesOtherFields` — confirms that editing
  one field does not destroy existing Vorbis Comment entries (write-mask
  correctness)

The core FLAC I/O (`readFLACTags` / `writeFLACTags` in `tags.go`) and
the tagger wiring were already in place from the issue #38
infrastructure work merged via PR #41.

## Test plan

- [x] `make test-short` — all unit tests pass including 5 FLAC-specific
  tests
- [x] `make test` — full suite passes (unit + ffmpeg integration)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)